### PR TITLE
document changes to the handlers to use the dbService

### DIFF
--- a/step-3/README.adoc
+++ b/step-3/README.adoc
@@ -149,7 +149,7 @@ include::src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java[tags=db
 
 <1> We just need to make sure to use the same event bus destination as the service that was published by  `WikiDatabaseVerticle`.
 
-Then, we need to replace calls to the event bus messages with calls to the database service:
+Then, we need to replace calls to the event bus with calls to the database service:
 
 [source,java,indent=0]
 ----

--- a/step-3/README.adoc
+++ b/step-3/README.adoc
@@ -137,16 +137,24 @@ What it does is actually very close to what we did in the previous section: mess
 
 == Obtaining a database service proxy
 
-The final step to refactoring to Vert.x services is to adapt the HTTP server verticle to obtain a proxy to the database service.
+The final steps to refactoring to Vert.x services is to adapt the HTTP server verticle to obtain a proxy to the database service
+and use it in the handlers instead of the event bus.
 
-All we need to do for that is creating the proxy when the verticle starts:
+First, we need to create the proxy when the verticle starts:
 
 [source,java,indent=0]
 ----
 include::src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java[tags=db-consume]
 ----
 
-We just need to make sure to use the same event bus destination as the service that was published by  `WikiDatabaseVerticle`.
+<1> We just need to make sure to use the same event bus destination as the service that was published by  `WikiDatabaseVerticle`.
+
+Then, we need to replace calls to the event bus messages with calls to the database service:
+
+[source,java,indent=0]
+----
+include::src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java[tags=db-service-calls]
+----
 
 The `WikiDatabaseServiceVertxProxyHandler` generated class deals with forwarding calls as event bus messages.
 

--- a/step-3/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
+++ b/step-3/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
@@ -57,7 +57,7 @@ public class HttpServerVerticle extends AbstractVerticle {
   @Override
   public void start(Future<Void> startFuture) throws Exception {
 
-    String wikiDbQueue = config().getString(CONFIG_WIKIDB_QUEUE, "wikidb.queue");
+    String wikiDbQueue = config().getString(CONFIG_WIKIDB_QUEUE, "wikidb.queue"); // <1>
     dbService = WikiDatabaseService.createProxy(vertx, wikiDbQueue);
 
     HttpServer server = vertx.createHttpServer();
@@ -86,7 +86,7 @@ public class HttpServerVerticle extends AbstractVerticle {
       });
   }
 
-
+  // tag::db-service-calls[]
   private void indexHandler(RoutingContext context) {
     dbService.fetchAllPages(reply -> {
       if (reply.succeeded()) {
@@ -179,4 +179,5 @@ public class HttpServerVerticle extends AbstractVerticle {
       }
     });
   }
+  // end::db-service-calls[]
 }


### PR DESCRIPTION
To go from step-2 to step-3, the handlers methods in HttpServerVerticle had to be adjusted to use WikiDatabaseService instead of the event bus; this pull request documents this.