### PR TITLE
Update vertx-maven-plugin and vertxVersion

### DIFF
--- a/step-1/README.adoc
+++ b/step-1/README.adoc
@@ -48,7 +48,7 @@ To generate a similar project as by cloning the Git starter repository:
 
     mkdir vertx-wiki
     cd vertx-wiki
-    mvn io.fabric8:vertx-maven-plugin:1.0.7:setup -DvertxVersion=3.5.0
+    mvn io.fabric8:vertx-maven-plugin:1.0.13:setup -DvertxVersion=3.5.1
     git init
 
 ====


### PR DESCRIPTION
In the Note discussing the Vert.x Maven Plugin (vmp), updated the vmp version to 1.0.13 and the Vert.x version to 3.5.1 - both the latest versions.