### PR TITLE
Use factory for service interface

### DIFF
--- a/step-3/README.adoc
+++ b/step-3/README.adoc
@@ -6,7 +6,7 @@ The previous refactoring was a big step forward compared to our initial implemen
 We also saw that we could deploy several instances of a given verticle to better cope with load and to better leverage CPU cores.
 
 In this section we see how to design and use Vert.x services.
-The main advantage of a service is that it defines an interface for doing certain operations that a verticle exposes.
+The main advantage of a service is that it defines an interface for doing certain operations that a verticle exposes - further improving the decoupling of code we started in step 2.
 We also leverage code generation for all the event bus messaging plumbing, instead of crafting it ourselves like we did in the previous section.
 
 We are also going to refactor the code into different Java packages:

--- a/step-3/README.adoc
+++ b/step-3/README.adoc
@@ -82,13 +82,13 @@ include::src/main/java/io/vertx/guides/wiki/database/WikiDatabaseService.java[ta
 3. Parameter types need to be strings, Java primitive types, JSON objects or arrays, any enumeration type or a `java.util` collection (`List` / `Set` / `Map`) of the previous types. The only way to support arbitrary Java classes is to have them as Vert.x data objects, annotated with `@DataObject`. The last opportunity to pass other types is service reference types.
 4. Since services provide asynchronous results, the last argument of a service method needs to be a `Handler<AsyncResult<T>>` where `T` is any of the types suitable for code generation as described above.
 
-It is a good practice that service interfaces provide static methods to create instances of both the actual service implementation and proxy for client code over the event bus.
+It is a good practice to use a Factory to create instances of both the actual service implementation and proxy for client code over the event bus. This would allow swapping the actual implementation in the future without needing to modify the client code.
 
 We define `create` as simply delegating to the implementation class and its constructor:
 
 [source,java,indent=0]
 ----
-include::src/main/java/io/vertx/guides/wiki/database/WikiDatabaseService.java[tags=create]
+include::src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceFactory.java[tags=create]
 ----
 
 The Vert.x code generator creates the proxy class and names it by suffixing with `VertxEBProxy`.
@@ -96,7 +96,7 @@ Constructors of these proxy classes need a reference to the Vert.x context as we
 
 [source,java,indent=0]
 ----
-include::src/main/java/io/vertx/guides/wiki/database/WikiDatabaseService.java[tags=proxy]
+include::src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceFactory.java[tags=proxy]
 ----
 
 NOTE: The `SqlQuery` and `ErrorCodes` enumeration types that were inner classes in the previous iteration have been extracted to package-protected types, see `SqlQuery.java` and `ErrorCodes.java`.

--- a/step-3/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceFactory.java
+++ b/step-3/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceFactory.java
@@ -17,39 +17,28 @@
 
 package io.vertx.guides.wiki.database;
 
-import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;
-
 import java.util.HashMap;
 
 /**
- * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
+ * @author <a href="https://ga.rgoyle.com/">Paul Court</a>
  */
-// tag::interface[]
-@ProxyGen
-public interface WikiDatabaseService {
+public class WikiDatabaseServiceFactory
+{
+    // tag::create[]
+    public static WikiDatabaseService create(JDBCClient dbClient, HashMap<SqlQuery, String> sqlQueries, Handler<AsyncResult<WikiDatabaseService>> readyHandler)
+    {
+        return new WikiDatabaseServiceImpl(dbClient, sqlQueries, readyHandler);
+    }
+    // end::create[]
 
-  @Fluent
-  WikiDatabaseService fetchAllPages(Handler<AsyncResult<JsonArray>> resultHandler);
-
-  @Fluent
-  WikiDatabaseService fetchPage(String name, Handler<AsyncResult<JsonObject>> resultHandler);
-
-  @Fluent
-  WikiDatabaseService createPage(String title, String markdown, Handler<AsyncResult<Void>> resultHandler);
-
-  @Fluent
-  WikiDatabaseService savePage(int id, String markdown, Handler<AsyncResult<Void>> resultHandler);
-
-  @Fluent
-  WikiDatabaseService deletePage(int id, Handler<AsyncResult<Void>> resultHandler);
-
-  // (...)
-  // end::interface[]
+    // tag::proxy[]
+    public static WikiDatabaseService createProxy(Vertx vertx, String address)
+    {
+        return new WikiDatabaseServiceVertxEBProxy(vertx, address);
+    }
+    // end::proxy[]
 }

--- a/step-3/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-3/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -51,7 +51,7 @@ public class WikiDatabaseVerticle extends AbstractVerticle {
       .put("driver_class", config().getString(CONFIG_WIKIDB_JDBC_DRIVER_CLASS, "org.hsqldb.jdbcDriver"))
       .put("max_pool_size", config().getInteger(CONFIG_WIKIDB_JDBC_MAX_POOL_SIZE, 30)));
 
-    WikiDatabaseService.create(dbClient, sqlQueries, ready -> {
+    WikiDatabaseServiceFactory.create(dbClient, sqlQueries, ready -> {
       if (ready.succeeded()) {
         ServiceBinder binder = new ServiceBinder(vertx);
         binder

--- a/step-3/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
+++ b/step-3/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
@@ -31,6 +31,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.templ.FreeMarkerTemplateEngine;
 import io.vertx.guides.wiki.database.WikiDatabaseService;
+import io.vertx.guides.wiki.database.WikiDatabaseServiceFactory;
 
 import java.util.Date;
 
@@ -58,7 +59,7 @@ public class HttpServerVerticle extends AbstractVerticle {
   public void start(Future<Void> startFuture) throws Exception {
 
     String wikiDbQueue = config().getString(CONFIG_WIKIDB_QUEUE, "wikidb.queue"); // <1>
-    dbService = WikiDatabaseService.createProxy(vertx, wikiDbQueue);
+    dbService = WikiDatabaseServiceFactory.createProxy(vertx, wikiDbQueue);
 
     HttpServer server = vertx.createHttpServer();
     // (...)


### PR DESCRIPTION
The existing example code results in a circular dependency between the `WikiDatabaseService` interface and `WikiDatabaseServiceImpl` class.

I've introduced a factory to eliminate the circular dependency and tweaked the surrounding wording to emphasise the abstraction a little bit more.