### PR TITLE
Removal of deprecated methods and classes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,8 @@ NOTE: This document is also link:{rendered-pdf-link}[available as a PDF].
 endif::[]
 
 .Acknowledgements
-This document has received contributions from Arnaud Esteve, Marc Paquette, Ashley Bye, Ger-Jan te Dorsthorst, Htet Aung Shine and others.
+This document has received contributions from Arnaud Esteve, Marc Paquette, Ashley Bye, Ger-Jan te Dorsthorst, Htet Aung Shine, Bruno Guimarães
+ and others.
 
 :imagesdir: intro
 include::intro/README.adoc[]

--- a/step-1/README.adoc
+++ b/step-1/README.adoc
@@ -48,7 +48,7 @@ To generate a similar project as by cloning the Git starter repository:
 
     mkdir vertx-wiki
     cd vertx-wiki
-    mvn io.fabric8:vertx-maven-plugin:1.0.13:setup -DvertxVersion=3.8.0
+    mvn io.fabric8:vertx-maven-plugin:1.0.13:setup -DvertxVersion=3.8.1
     git init
 
 ====

--- a/step-1/README.adoc
+++ b/step-1/README.adoc
@@ -48,7 +48,7 @@ To generate a similar project as by cloning the Git starter repository:
 
     mkdir vertx-wiki
     cd vertx-wiki
-    mvn io.fabric8:vertx-maven-plugin:1.0.13:setup -DvertxVersion=3.8.1
+    mvn io.fabric8:vertx-maven-plugin:1.0.13:setup -DvertxVersion=3.8.2
     git init
 
 ====

--- a/step-1/pom.xml
+++ b/step-1/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-1/pom.xml
+++ b/step-1/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-1/pom.xml
+++ b/step-1/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
     <!-- end::db-deps[] -->
 

--- a/step-10/pom.xml
+++ b/step-10/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-10/pom.xml
+++ b/step-10/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-10/pom.xml
+++ b/step-10/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-10/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-10/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.reactivex.Single;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.reactivex.core.AbstractVerticle;
 

--- a/step-10/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceImpl.java
+++ b/step-10/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceImpl.java
@@ -28,8 +28,6 @@ import io.vertx.reactivex.CompletableHelper;
 import io.vertx.reactivex.SingleHelper;
 import io.vertx.reactivex.ext.jdbc.JDBCClient;
 import io.vertx.reactivex.ext.sql.SQLClientHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,8 +36,6 @@ import java.util.List;
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
 class WikiDatabaseServiceImpl implements WikiDatabaseService {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(WikiDatabaseServiceImpl.class);
 
   private final HashMap<SqlQuery, String> sqlQueries;
   private final JDBCClient dbClient;

--- a/step-10/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-10/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-10/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
+++ b/step-10/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki.http;
 
 import com.github.rjeschke.txtmark.Processor;
 import io.reactivex.Flowable;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -31,7 +30,6 @@ import io.vertx.reactivex.core.http.HttpServer;
 import io.vertx.reactivex.ext.web.Router;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import io.vertx.reactivex.ext.web.handler.BodyHandler;
-import io.vertx.reactivex.ext.web.handler.CookieHandler;
 import io.vertx.reactivex.ext.web.handler.SessionHandler;
 import io.vertx.reactivex.ext.web.handler.StaticHandler;
 import io.vertx.reactivex.ext.web.handler.sockjs.SockJSHandler;
@@ -63,7 +61,6 @@ public class HttpServerVerticle extends AbstractVerticle {
 
     Router router = Router.router(vertx);
 
-    router.route().handler(CookieHandler.create());
     router.route().handler(BodyHandler.create());
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
 

--- a/step-2/pom.xml
+++ b/step-2/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-2/pom.xml
+++ b/step-2/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-2/pom.xml
+++ b/step-2/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-2/src/main/java/io/vertx/guides/wiki/HttpServerVerticle.java
+++ b/step-2/src/main/java/io/vertx/guides/wiki/HttpServerVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import com.github.rjeschke.txtmark.Processor;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.HttpServer;

--- a/step-2/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-2/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 
 /**

--- a/step-2/src/main/java/io/vertx/guides/wiki/WikiDatabaseVerticle.java
+++ b/step-2/src/main/java/io/vertx/guides/wiki/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;

--- a/step-3/pom.xml
+++ b/step-3/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <!-- tag::codegen-dep[] -->

--- a/step-3/pom.xml
+++ b/step-3/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-3/pom.xml
+++ b/step-3/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-3/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-3/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.guides.wiki.database.WikiDatabaseVerticle;
 

--- a/step-3/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-3/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-4/pom.xml
+++ b/step-4/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-4/pom.xml
+++ b/step-4/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-4/pom.xml
+++ b/step-4/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-4/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-4/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.guides.wiki.database.WikiDatabaseVerticle;
 

--- a/step-4/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-4/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-4/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
+++ b/step-4/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
@@ -17,7 +17,6 @@
 
 package io.vertx.guides.wiki.http;
 
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;

--- a/step-5/pom.xml
+++ b/step-5/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-5/pom.xml
+++ b/step-5/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-5/pom.xml
+++ b/step-5/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-5/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-5/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.guides.wiki.database.WikiDatabaseVerticle;
 

--- a/step-5/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-5/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-5/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
+++ b/step-5/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
@@ -17,7 +17,6 @@
 
 package io.vertx.guides.wiki.http;
 
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;

--- a/step-6/pom.xml
+++ b/step-6/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-6/pom.xml
+++ b/step-6/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-6/pom.xml
+++ b/step-6/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-6/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-6/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-6/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
+++ b/step-6/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
@@ -17,7 +17,6 @@
 
 package io.vertx.guides.wiki.http;
 
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;

--- a/step-7/README.adoc
+++ b/step-7/README.adoc
@@ -241,14 +241,6 @@ We start by adding the `vertx-auth-jwt` module to the Maven dependencies:
 include::pom.xml[tags=jwt]
 ----
 
-We will have a JCEKS keystore to hold the keys for our tests.
-Here is how to generate a `keystore.jceks` with the suitable keys of various lengths:
-
-[source,text,indent=0]
-----
-include::gen-keystore.sh[tags=jwt-keygen]
-----
-
 We need to install a JWT token handler on API routes:
 
 [source,java,indent=0]

--- a/step-7/gen-keystore.sh
+++ b/step-7/gen-keystore.sh
@@ -1,19 +1,5 @@
 #!/bin/sh
 
-echo "Keys for JWT..."
-
-# tag::jwt-keygen[]
-keytool -genseckey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg HMacSHA256 -keysize 2048 -alias HS256 -keypass secret
-keytool -genseckey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg HMacSHA384 -keysize 2048 -alias HS384 -keypass secret
-keytool -genseckey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg HMacSHA512 -keysize 2048 -alias HS512 -keypass secret
-keytool -genkey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg RSA -keysize 2048 -alias RS256 -keypass secret -sigalg SHA256withRSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg RSA -keysize 2048 -alias RS384 -keypass secret -sigalg SHA384withRSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg RSA -keysize 2048 -alias RS512 -keypass secret -sigalg SHA512withRSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkeypair -keystore keystore.jceks -storetype jceks -storepass secret -keyalg EC -keysize 256 -alias ES256 -keypass secret -sigalg SHA256withECDSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkeypair -keystore keystore.jceks -storetype jceks -storepass secret -keyalg EC -keysize 256 -alias ES384 -keypass secret -sigalg SHA384withECDSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkeypair -keystore keystore.jceks -storetype jceks -storepass secret -keyalg EC -keysize 256 -alias ES512 -keypass secret -sigalg SHA512withECDSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-# end::jwt-keygen[]
-
 echo "Keys for HTTPS..."
 
 # tag::https-keygen[]

--- a/step-7/pom.xml
+++ b/step-7/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-7/pom.xml
+++ b/step-7/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <!--tag::jdbc-auth[] -->

--- a/step-7/pom.xml
+++ b/step-7/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-7/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-7/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-7/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
+++ b/step-7/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
@@ -24,7 +24,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
-import io.vertx.ext.auth.KeyStoreOptions;
+import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jdbc.JDBCAuth;
 import io.vertx.ext.auth.jwt.JWTAuth;
@@ -102,10 +102,8 @@ public class HttpServerVerticle extends AbstractVerticle {
     // tag::auth-routes[]
     Router router = Router.router(vertx);
 
-    router.route().handler(CookieHandler.create());
     router.route().handler(BodyHandler.create());
-    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
-    router.route().handler(UserSessionHandler.create(auth));  // <1>
+    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)).setAuthProvider(auth)); // <1>
 
     AuthHandler authHandler = RedirectAuthHandler.create(auth, "/login"); // <2>
     router.route("/").handler(authHandler);  // <3>
@@ -137,10 +135,10 @@ public class HttpServerVerticle extends AbstractVerticle {
     Router apiRouter = Router.router(vertx);
 
     JWTAuth jwtAuth = JWTAuth.create(vertx, new JWTAuthOptions()
-      .setKeyStore(new KeyStoreOptions()
-        .setPath("keystore.jceks")
-        .setType("jceks")
-        .setPassword("secret")));
+      .addPubSecKey(new PubSecKeyOptions()
+        .setAlgorithm("HS256")
+        .setPublicKey("secret")
+        .setSymmetric(true)));
 
     apiRouter.route().handler(JWTAuthHandler.create(jwtAuth, "/api/token"));
     // end::jwtAuth[]

--- a/step-7/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
+++ b/step-7/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
@@ -17,7 +17,6 @@
 
 package io.vertx.guides.wiki.http;
 
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;

--- a/step-8/gen-keystore.sh
+++ b/step-8/gen-keystore.sh
@@ -1,17 +1,5 @@
 #!/bin/sh
 
-echo "Keys for JWT..."
-
-keytool -genseckey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg HMacSHA256 -keysize 2048 -alias HS256 -keypass secret
-keytool -genseckey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg HMacSHA384 -keysize 2048 -alias HS384 -keypass secret
-keytool -genseckey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg HMacSHA512 -keysize 2048 -alias HS512 -keypass secret
-keytool -genkey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg RSA -keysize 2048 -alias RS256 -keypass secret -sigalg SHA256withRSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg RSA -keysize 2048 -alias RS384 -keypass secret -sigalg SHA384withRSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkey -keystore keystore.jceks -storetype jceks -storepass secret -keyalg RSA -keysize 2048 -alias RS512 -keypass secret -sigalg SHA512withRSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkeypair -keystore keystore.jceks -storetype jceks -storepass secret -keyalg EC -keysize 256 -alias ES256 -keypass secret -sigalg SHA256withECDSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkeypair -keystore keystore.jceks -storetype jceks -storepass secret -keyalg EC -keysize 256 -alias ES384 -keypass secret -sigalg SHA384withECDSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-keytool -genkeypair -keystore keystore.jceks -storetype jceks -storepass secret -keyalg EC -keysize 256 -alias ES512 -keypass secret -sigalg SHA512withECDSA -dname "CN=,OU=,O=,L=,ST=,C=" -validity 360
-
 echo "Keys for HTTPS..."
 
 keytool -genkey -alias test -keyalg RSA -keystore server-keystore.jks -keysize 2048 -validity 360 -dname CN=localhost -keypass secret -storepass secret

--- a/step-8/pom.xml
+++ b/step-8/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-8/pom.xml
+++ b/step-8/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-8/pom.xml
+++ b/step-8/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-8/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-8/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.reactivex.Single;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.reactivex.core.AbstractVerticle;
 

--- a/step-8/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceImpl.java
+++ b/step-8/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceImpl.java
@@ -28,8 +28,6 @@ import io.vertx.reactivex.CompletableHelper;
 import io.vertx.reactivex.SingleHelper;
 import io.vertx.reactivex.ext.jdbc.JDBCClient;
 import io.vertx.reactivex.ext.sql.SQLClientHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,8 +36,6 @@ import java.util.List;
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
 class WikiDatabaseServiceImpl implements WikiDatabaseService {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(WikiDatabaseServiceImpl.class);
 
   private final HashMap<SqlQuery, String> sqlQueries;
   private final JDBCClient dbClient;
@@ -117,7 +113,7 @@ class WikiDatabaseServiceImpl implements WikiDatabaseService {
   @Override
   public WikiDatabaseService createPage(String title, String markdown, Handler<AsyncResult<Void>> resultHandler) {
     dbClient.rxUpdateWithParams(sqlQueries.get(SqlQuery.CREATE_PAGE), new JsonArray().add(title).add(markdown))
-      .toCompletable()
+      .ignoreElement()
       .subscribe(CompletableHelper.toObserver(resultHandler));
     return this;
   }
@@ -125,7 +121,7 @@ class WikiDatabaseServiceImpl implements WikiDatabaseService {
   @Override
   public WikiDatabaseService savePage(int id, String markdown, Handler<AsyncResult<Void>> resultHandler) {
     dbClient.rxUpdateWithParams(sqlQueries.get(SqlQuery.SAVE_PAGE), new JsonArray().add(markdown).add(id))
-      .toCompletable()
+      .ignoreElement()
       .subscribe(CompletableHelper.toObserver(resultHandler));
     return this;
   }
@@ -134,7 +130,7 @@ class WikiDatabaseServiceImpl implements WikiDatabaseService {
   public WikiDatabaseService deletePage(int id, Handler<AsyncResult<Void>> resultHandler) {
     JsonArray data = new JsonArray().add(id);
     dbClient.rxUpdateWithParams(sqlQueries.get(SqlQuery.DELETE_PAGE), data)
-      .toCompletable()
+      .ignoreElement()
       .subscribe(CompletableHelper.toObserver(resultHandler));
     return this;
   }

--- a/step-8/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-8/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-8/src/main/java/io/vertx/guides/wiki/http/AuthInitializerVerticle.java
+++ b/step-8/src/main/java/io/vertx/guides/wiki/http/AuthInitializerVerticle.java
@@ -81,7 +81,7 @@ public class AuthInitializerVerticle extends AbstractVerticle {
             logger.info("Need to insert data");
             return connection
               .rxBatch(dataInit)
-              .toCompletable();
+              .ignoreElement();
           } else {
             logger.info("No need to insert data");
             return Completable.complete();

--- a/step-8/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
+++ b/step-8/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
@@ -21,13 +21,12 @@ import com.github.rjeschke.txtmark.Processor;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
-import io.vertx.ext.auth.KeyStoreOptions;
+import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.jwt.JWTOptions;
 import io.vertx.ext.web.client.WebClientOptions;
@@ -103,10 +102,8 @@ public class HttpServerVerticle extends AbstractVerticle {
 
     Router router = Router.router(vertx);
 
-    router.route().handler(CookieHandler.create());
     router.route().handler(BodyHandler.create());
-    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
-    router.route().handler(UserSessionHandler.create(auth));
+    router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)).setAuthProvider(auth));
 
     AuthHandler authHandler = RedirectAuthHandler.create(auth, "/login");
     router.route("/").handler(authHandler);
@@ -132,10 +129,10 @@ public class HttpServerVerticle extends AbstractVerticle {
     });
 
     JWTAuth jwtAuth = JWTAuth.create(vertx, new JWTAuthOptions()
-      .setKeyStore(new KeyStoreOptions()
-        .setPath("keystore.jceks")
-        .setType("jceks")
-        .setPassword("secret")));
+      .addPubSecKey(new PubSecKeyOptions()
+        .setAlgorithm("HS256")
+        .setPublicKey("secret")
+        .setSymmetric(true)));
 
     Router apiRouter = Router.router(vertx);
     templateEngine = FreeMarkerTemplateEngine.create(vertx);

--- a/step-8/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
+++ b/step-8/src/test/java/io/vertx/guides/wiki/http/SampleHttpServerTest.java
@@ -17,7 +17,6 @@
 
 package io.vertx.guides.wiki.http;
 
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;

--- a/step-9/pom.xml
+++ b/step-9/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.0</vertx.version>
+    <vertx.version>3.8.1</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-9/pom.xml
+++ b/step-9/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/step-9/pom.xml
+++ b/step-9/pom.xml
@@ -27,7 +27,7 @@
   <version>1.5.0</version>
 
   <properties>
-    <vertx.version>3.8.1</vertx.version>
+    <vertx.version>3.8.2</vertx.version>
     <main.verticle>io.vertx.guides.wiki.MainVerticle</main.verticle>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/step-9/src/main/java/io/vertx/guides/wiki/MainVerticle.java
+++ b/step-9/src/main/java/io/vertx/guides/wiki/MainVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki;
 
 import io.reactivex.Single;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.reactivex.core.AbstractVerticle;
 

--- a/step-9/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceImpl.java
+++ b/step-9/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseServiceImpl.java
@@ -28,8 +28,6 @@ import io.vertx.reactivex.CompletableHelper;
 import io.vertx.reactivex.SingleHelper;
 import io.vertx.reactivex.ext.jdbc.JDBCClient;
 import io.vertx.reactivex.ext.sql.SQLClientHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,8 +36,6 @@ import java.util.List;
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
 class WikiDatabaseServiceImpl implements WikiDatabaseService {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(WikiDatabaseServiceImpl.class);
 
   private final HashMap<SqlQuery, String> sqlQueries;
   private final JDBCClient dbClient;
@@ -110,7 +106,7 @@ class WikiDatabaseServiceImpl implements WikiDatabaseService {
   @Override
   public WikiDatabaseService createPage(String title, String markdown, Handler<AsyncResult<Void>> resultHandler) {
     dbClient.rxUpdateWithParams(sqlQueries.get(SqlQuery.CREATE_PAGE), new JsonArray().add(title).add(markdown))
-      .toCompletable()
+      .ignoreElement()
       .subscribe(CompletableHelper.toObserver(resultHandler));
     return this;
   }
@@ -118,7 +114,7 @@ class WikiDatabaseServiceImpl implements WikiDatabaseService {
   @Override
   public WikiDatabaseService savePage(int id, String markdown, Handler<AsyncResult<Void>> resultHandler) {
     dbClient.rxUpdateWithParams(sqlQueries.get(SqlQuery.SAVE_PAGE), new JsonArray().add(markdown).add(id))
-      .toCompletable()
+      .ignoreElement()
       .subscribe(CompletableHelper.toObserver(resultHandler));
     return this;
   }
@@ -127,7 +123,7 @@ class WikiDatabaseServiceImpl implements WikiDatabaseService {
   public WikiDatabaseService deletePage(int id, Handler<AsyncResult<Void>> resultHandler) {
     JsonArray data = new JsonArray().add(id);
     dbClient.rxUpdateWithParams(sqlQueries.get(SqlQuery.DELETE_PAGE), data)
-      .toCompletable()
+      .ignoreElement()
       .subscribe(CompletableHelper.toObserver(resultHandler));
     return this;
   }

--- a/step-9/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
+++ b/step-9/src/main/java/io/vertx/guides/wiki/database/WikiDatabaseVerticle.java
@@ -18,7 +18,6 @@
 package io.vertx.guides.wiki.database;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.jdbc.JDBCClient;

--- a/step-9/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
+++ b/step-9/src/main/java/io/vertx/guides/wiki/http/HttpServerVerticle.java
@@ -19,7 +19,6 @@ package io.vertx.guides.wiki.http;
 
 import com.github.rjeschke.txtmark.Processor;
 import io.reactivex.Flowable;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -29,7 +28,6 @@ import io.vertx.reactivex.core.http.HttpServer;
 import io.vertx.reactivex.ext.web.Router;
 import io.vertx.reactivex.ext.web.RoutingContext;
 import io.vertx.reactivex.ext.web.handler.BodyHandler;
-import io.vertx.reactivex.ext.web.handler.CookieHandler;
 import io.vertx.reactivex.ext.web.handler.SessionHandler;
 import io.vertx.reactivex.ext.web.handler.StaticHandler;
 import io.vertx.reactivex.ext.web.sstore.LocalSessionStore;
@@ -60,7 +58,6 @@ public class HttpServerVerticle extends AbstractVerticle {
 
     Router router = Router.router(vertx);
 
-    router.route().handler(CookieHandler.create());
     router.route().handler(BodyHandler.create());
     router.route().handler(SessionHandler.create(LocalSessionStore.create(vertx)));
 


### PR DESCRIPTION
- Removed unused imports and variables
- Bumped Vert.x version to 3.8.1
- Removed deprecated `io.vertx.ext.web.handler.CookieHandler` (since it's now enabled by default)
- Removed deprecated `io.vertx.ext.web.handler.UserSessionHandler` (moved user session logic to `io.vertx.ext.web.handler.SessionHandler`)
- Removed deprecated calls to `Single.toCompletable` (replaced them by `Single.ignoreElement`)
- Removed deprecated JWT key loading from keystores (using PubSec now instead)