### PR TITLE
Fix the clean target by removing the whole "target" dir

### DIFF
--- a/step-9/pom.xml
+++ b/step-9/pom.xml
@@ -148,6 +148,7 @@
             <filesets>
               <fileset>
                 <directory>${project.basedir}/src/main/generated</directory>
+                <directory>${project.basedir}/target</directory>
               </fileset>
             </filesets>
           </configuration>


### PR DESCRIPTION
This also fixes the broken proxy service generation which results in missing rx... methods, see #19